### PR TITLE
Table helper is deprecated.

### DIFF
--- a/src/Vendor/Laravel/Artisan/Report.php
+++ b/src/Vendor/Laravel/Artisan/Report.php
@@ -2,6 +2,8 @@
 
 namespace PragmaRX\Firewall\Vendor\Laravel\Artisan;
 
+use Symfony\Component\Console\Helper\Table;
+
 class Report extends Base
 {
     /**
@@ -39,7 +41,7 @@ class Report extends Base
      * @return mixed
      */
     public function fire() {
-        $this->table = $this->getHelperSet()->get('table');
+        $this->table = new Table($this->output);
 
         $list = [];
 


### PR DESCRIPTION
It throws error when I try to run artisan command
~~~
  [Symfony\Component\Console\Exception\InvalidArgumentException]
  The helper "table" is not defined.
~~~

Table helper is deprecated